### PR TITLE
Default to the processor's arch as host and target arch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Inputs
 ------
 
 - `vswhere`: Path to `vswhere.exe` (default system-installed copy).
-- `arch`: Build architecture (default `amd64`).
-- `host_arch`: Host architecture override.
+- `host_arch`: Host architecture override (defaults to the processor architecture).
+- `arch`: Build architecture (defaults to the value of host_arch).
 - `winsdk`: WinSDK version override.
 - `toolset_version`: Build toolset version override.
-- `components`: List of required VS components, semi-colon separated. (default `Microsoft.VisualStudio.Component.VC.Tools.x86.x64`)
+- `components`: List of required VS components, semi-colon separated. (includes the latest toolset for `arch` by default)
 - `verbose`: Display information about the installation that `vswhere` selects.
 
 Outputs

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ inputs:
     description: 'Name or path to vswhere.exr'
     default: 'vswhere.exe'
   arch:
-    description: 'Determines the 'arch' argument to vcvarsall (x86, amd64/x64, arm, arm64, or arm64ec). Defaults to the value of host_arch.'
+    description: 'Determines the \'arch\' argument to vcvarsall (x86, amd64/x64, arm, arm64, or arm64ec). Defaults to the value of host_arch.'
     default: ''
   host_arch:
-    description: 'Determines the 'host_arch' parameter to vcvarsall (x86, amd64/x64, or arm64). Defaults to the current processor architecture.'
+    description: 'Determines the \'host_arch\' parameter to vcvarsall (x86, amd64/x64, or arm64). Defaults to the current processor architecture.'
     default: ''
   winsdk:
     description: 'Overrides the default WinSDK version'

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ inputs:
     description: 'Name or path to vswhere.exr'
     default: 'vswhere.exe'
   arch:
-    description: 'Target build architecture'
-    default: 'amd64'
+    description: 'Target build architecture (x86, amd64/x64, arm, or arm64). Defaults to the value of host_arch.'
+    default: ''
   host_arch:
-    description: 'Host architecture (x86, x86_amd64, or amd64)'
+    description: 'Host architecture (x86, amd64/x64, or arm64). Defaults to the current processor architecture.'
     default: ''
   winsdk:
     description: 'Overrides the default WinSDK version'
@@ -21,7 +21,7 @@ inputs:
     default: ''
   components:
     description: 'List of components required in the selected VS installation (semi-colon separated)'
-    default: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+    default: ''
   verbose:
     description: 'Display additional information about the VS Installation'
     default: false

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ inputs:
     description: 'Name or path to vswhere.exr'
     default: 'vswhere.exe'
   arch:
-    description: 'Determines the \'arch\' argument to vcvarsall (x86, amd64/x64, arm, arm64, or arm64ec). Defaults to the value of host_arch.'
+    description: "Determines the 'arch' argument to vcvarsall (x86, amd64/x64, arm, arm64, or arm64ec). Defaults to the value of host_arch."
     default: ''
   host_arch:
-    description: 'Determines the \'host_arch\' parameter to vcvarsall (x86, amd64/x64, or arm64). Defaults to the current processor architecture.'
+    description: "Determines the 'host_arch' parameter to vcvarsall (x86, amd64/x64, or arm64). Defaults to the current processor architecture."
     default: ''
   winsdk:
     description: 'Overrides the default WinSDK version'

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ inputs:
     description: 'Name or path to vswhere.exr'
     default: 'vswhere.exe'
   arch:
-    description: 'Target build architecture (x86, amd64/x64, arm, or arm64). Defaults to the value of host_arch.'
+    description: 'Determines the 'arch' argument to vcvarsall (x86, amd64/x64, arm, arm64, or arm64ec). Defaults to the value of host_arch.'
     default: ''
   host_arch:
-    description: 'Host architecture (x86, amd64/x64, or arm64). Defaults to the current processor architecture.'
+    description: 'Determines the 'host_arch' parameter to vcvarsall (x86, amd64/x64, or arm64). Defaults to the current processor architecture.'
     default: ''
   winsdk:
     description: 'Overrides the default WinSDK version'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2953,6 +2953,7 @@ try {
 
     const cmdResult = spawn('cmd', cmdArgs, {encoding: 'utf8'})
     if (cmdResult.error) throw cmdResult.error
+
     const cmdOutput = cmdResult.output
         .filter(s => !!s)
         .map(s => s.split('\n'))

--- a/dist/index.js
+++ b/dist/index.js
@@ -2849,6 +2849,8 @@ function getInputs() {
         // Include the latest target architecture compiler toolset by default
         if (arch === 'arm64')
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM64')
+        else if (arch === 'arm64ec')
+            components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM64EC')
         else if (arch == 'arm')
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM')
         else

--- a/dist/index.js
+++ b/dist/index.js
@@ -2877,7 +2877,9 @@ function findVSWhere(inputs) {
     return vswherePath
 }
 
-function findVSInstallDir(vswherePath, inputs) {
+function findVSInstallDir(inputs) {
+    const vswherePath = findVSWhere(inputs)
+
     const requiresArg = inputs.components
         .map(comp => ['-requires', comp])
         .reduce((arr, pair) => arr.concat(pair), [])
@@ -2941,7 +2943,7 @@ try {
 
     var inputs = getInputs()
 
-    const installPath = findVSInstallDir(findVSWhere(), inputs)
+    const installPath = findVSInstallDir(inputs)
     core.setOutput('install_path', installPath)
 
     const vsDevCmdPath = path.win32.join(installPath, 'Common7', 'Tools', 'vsdevcmd.bat')

--- a/dist/index.js
+++ b/dist/index.js
@@ -2896,7 +2896,7 @@ function findVSInstallDir(inputs) {
     const vswhereResult = spawn(vswherePath, vswhereArgs, {encoding: 'utf8'})
     if (vswhereResult.error) throw vswhereResult.error
 
-    if (verbose) {
+    if (inputs.verbose) {
       const args = [
         '-nologo',
         '-latest',

--- a/dist/index.js
+++ b/dist/index.js
@@ -2865,6 +2865,7 @@ function getInputs() {
         "winsdk": core.getInput('winsdk') || null,
         "vswhere": core.getInput('vswhere') || null,
         "components": components,
+        // Action inputs are stringly-typed, and Boolean("false") === true, so prefer:
         "verbose": String(core.getInput('verbose')) === "true"
     }
 }
@@ -2893,17 +2894,17 @@ function findVSInstallDir(inputs) {
 
     console.log(`$ ${vswherePath} ${vswhereArgs.join(' ')}`)
 
-    const vswhereResult = spawn(vswherePath, vswhereArgs, {encoding: 'utf8'})
+    const vswhereResult = spawn(vswherePath, vswhereArgs, { encoding: 'utf8' })
     if (vswhereResult.error) throw vswhereResult.error
 
     if (inputs.verbose) {
-      const args = [
-        '-nologo',
-        '-latest',
-        '-products', '*',
-      ].concat(requiresArg)
-      const details = spawn(vswherePath, args, { encoding: 'utf8' })
-      console.log(details.output.join(''))
+        const args = [
+            '-nologo',
+            '-latest',
+            '-products', '*',
+        ].concat(requiresArg)
+        const details = spawn(vswherePath, args, { encoding: 'utf8' })
+        console.log(details.output.join(''))
     }
 
     const installPathList = vswhereResult.output.filter(s => !!s).map(s => s.trim())
@@ -2950,10 +2951,10 @@ try {
     console.log(`vsdevcmd: ${vsDevCmdPath}`)
 
     const vsDevCmdArgs = getVSDevCmdArgs(inputs)
-    const cmdArgs = [].concat(['/q', '/k', vsDevCmdPath], vsDevCmdArgs, ['&&', 'set'])
+    const cmdArgs = ['/q', '/k', vsDevCmdPath, ...vsDevCmdArgs, '&&', 'set']
     console.log(`$ cmd ${cmdArgs.join(' ')}`)
 
-    const cmdResult = spawn('cmd', cmdArgs, {encoding: 'utf8'})
+    const cmdResult = spawn('cmd', cmdArgs, { encoding: 'utf8' })
     if (cmdResult.error) throw cmdResult.error
 
     const cmdOutput = cmdResult.output
@@ -2969,9 +2970,9 @@ try {
     const newEnvVars = completeEnv
         .filter(([key, _]) => !index_process.env[key])
     const newPath = completeEnv
-                        .filter(([key, _]) => key == 'Path')
-                        .map(([_, value]) => value)
-                        .join(';');
+        .filter(([key, _]) => key == 'Path')
+        .map(([_, value]) => value)
+        .join(';');
 
     for (const [key, value] of newEnvVars) {
         core.exportVariable(key, value)

--- a/dist/index.js
+++ b/dist/index.js
@@ -2847,10 +2847,10 @@ function getInputs() {
     const components = core.getInput('components').split(';').filter(s => s.length != 0)
     if (!toolsetVersion) {
         // Include the latest target architecture compiler toolset by default
-        if (inputs.arch === 'arm64') {
+        if (arch === 'arm64') {
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM64')
         }
-        else if (inputs.arch == 'arm') {
+        else if (arch == 'arm') {
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM')
         }
         else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2865,7 +2865,7 @@ function getInputs() {
         "winsdk": core.getInput('winsdk') || null,
         "vswhere": core.getInput('vswhere') || null,
         "components": components,
-        "verbose": Boolean(core.getInput('verbose'))
+        "verbose": String(core.getInput('verbose')) === "true"
     }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2847,15 +2847,12 @@ function getInputs() {
     const components = core.getInput('components').split(';').filter(s => s.length != 0)
     if (!toolsetVersion) {
         // Include the latest target architecture compiler toolset by default
-        if (arch === 'arm64') {
+        if (arch === 'arm64')
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM64')
-        }
-        else if (arch == 'arm') {
+        else if (arch == 'arm')
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM')
-        }
-        else {
+        else
             components.push('Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
-        }
     }
 
     return {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,9 @@ function findVSWhere(inputs) {
     return vswherePath
 }
 
-function findVSInstallDir(vswherePath, inputs) {
+function findVSInstallDir(inputs) {
+    const vswherePath = findVSWhere(inputs)
+
     const requiresArg = inputs.components
         .map(comp => ['-requires', comp])
         .reduce((arr, pair) => arr.concat(pair), [])
@@ -108,7 +110,7 @@ try {
 
     var inputs = getInputs()
 
-    const installPath = findVSInstallDir(findVSWhere(), inputs)
+    const installPath = findVSInstallDir(inputs)
     core.setOutput('install_path', installPath)
 
     const vsDevCmdPath = path.win32.join(installPath, 'Common7', 'Tools', 'vsdevcmd.bat')

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function getInputs() {
         "winsdk": core.getInput('winsdk') || null,
         "vswhere": core.getInput('vswhere') || null,
         "components": components,
-        "verbose": Boolean(core.getInput('verbose'))
+        "verbose": String(core.getInput('verbose')) === "true"
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ function getInputs() {
         // Include the latest target architecture compiler toolset by default
         if (arch === 'arm64')
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM64')
+        else if (arch === 'arm64ec')
+            components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM64EC')
         else if (arch == 'arm')
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM')
         else

--- a/index.js
+++ b/index.js
@@ -14,15 +14,12 @@ function getInputs() {
     const components = core.getInput('components').split(';').filter(s => s.length != 0)
     if (!toolsetVersion) {
         // Include the latest target architecture compiler toolset by default
-        if (arch === 'arm64') {
+        if (arch === 'arm64')
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM64')
-        }
-        else if (arch == 'arm') {
+        else if (arch == 'arm')
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM')
-        }
-        else {
+        else
             components.push('Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
-        }
     }
 
     return {

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function findVSInstallDir(inputs) {
     const vswhereResult = spawn(vswherePath, vswhereArgs, {encoding: 'utf8'})
     if (vswhereResult.error) throw vswhereResult.error
 
-    if (verbose) {
+    if (inputs.verbose) {
       const args = [
         '-nologo',
         '-latest',

--- a/index.js
+++ b/index.js
@@ -14,10 +14,10 @@ function getInputs() {
     const components = core.getInput('components').split(';').filter(s => s.length != 0)
     if (!toolsetVersion) {
         // Include the latest target architecture compiler toolset by default
-        if (inputs.arch === 'arm64') {
+        if (arch === 'arm64') {
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM64')
         }
-        else if (inputs.arch == 'arm') {
+        else if (arch == 'arm') {
             components.push('Microsoft.VisualStudio.Component.VC.Tools.ARM')
         }
         else {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function getInputs() {
         "winsdk": core.getInput('winsdk') || null,
         "vswhere": core.getInput('vswhere') || null,
         "components": components,
+        // Action inputs are stringly-typed, and Boolean("false") === true, so prefer:
         "verbose": String(core.getInput('verbose')) === "true"
     }
 }
@@ -60,17 +61,17 @@ function findVSInstallDir(inputs) {
 
     console.log(`$ ${vswherePath} ${vswhereArgs.join(' ')}`)
 
-    const vswhereResult = spawn(vswherePath, vswhereArgs, {encoding: 'utf8'})
+    const vswhereResult = spawn(vswherePath, vswhereArgs, { encoding: 'utf8' })
     if (vswhereResult.error) throw vswhereResult.error
 
     if (inputs.verbose) {
-      const args = [
-        '-nologo',
-        '-latest',
-        '-products', '*',
-      ].concat(requiresArg)
-      const details = spawn(vswherePath, args, { encoding: 'utf8' })
-      console.log(details.output.join(''))
+        const args = [
+            '-nologo',
+            '-latest',
+            '-products', '*',
+        ].concat(requiresArg)
+        const details = spawn(vswherePath, args, { encoding: 'utf8' })
+        console.log(details.output.join(''))
     }
 
     const installPathList = vswhereResult.output.filter(s => !!s).map(s => s.trim())
@@ -117,10 +118,10 @@ try {
     console.log(`vsdevcmd: ${vsDevCmdPath}`)
 
     const vsDevCmdArgs = getVSDevCmdArgs(inputs)
-    const cmdArgs = [].concat(['/q', '/k', vsDevCmdPath], vsDevCmdArgs, ['&&', 'set'])
+    const cmdArgs = ['/q', '/k', vsDevCmdPath, ...vsDevCmdArgs, '&&', 'set']
     console.log(`$ cmd ${cmdArgs.join(' ')}`)
 
-    const cmdResult = spawn('cmd', cmdArgs, {encoding: 'utf8'})
+    const cmdResult = spawn('cmd', cmdArgs, { encoding: 'utf8' })
     if (cmdResult.error) throw cmdResult.error
 
     const cmdOutput = cmdResult.output
@@ -136,9 +137,9 @@ try {
     const newEnvVars = completeEnv
         .filter(([key, _]) => !process.env[key])
     const newPath = completeEnv
-                        .filter(([key, _]) => key == 'Path')
-                        .map(([_, value]) => value)
-                        .join(';');
+        .filter(([key, _]) => key == 'Path')
+        .map(([_, value]) => value)
+        .join(';');
 
     for (const [key, value] of newEnvVars) {
         core.exportVariable(key, value)


### PR DESCRIPTION
Previously when running on an arm64 runner, the vsdevcmd would be configured to cross-build to amd64 by default. Better default to the host architecture, which itself defaults to the processor architecture.

Likewise, `components` would default to looking for the x64 compiler, but we should rather look for the compiler based on `arch`.