### PR TITLE
action: run on `node24`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,5 +24,6 @@ jobs:
         with:
           winsdk: 10.0.22621.0
       - run: 'cl /EHsc /Fe:test.exe tests\\test.cpp && .\\test.exe'
+        shell: cmd
         if: runner.os == 'Windows'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - uses: ./
         with:
           winsdk: 10.0.22621.0

--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ outputs:
   install_path:
     description: 'VS installation path'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Ref. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ support for `node20` is deprecated and will go away.

Fixes https://github.com/compnerd/gha-setup-vsdevenv/issues/8